### PR TITLE
Create contribution guide

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,19 @@
+Issue Description
+=================
+A clear and concise description of what the bug is.
+
+Expected Result
+============
+A clear and concise description of what you expected to happen.
+
+How to Reproduce
+===============
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+Further Information
+===============
+* A link to an ObsRailsTemplate instance showing the issue
+* Any other additional details to help maintainers reproduce the problem.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+Is your feature request related to a problem? Please describe
+=============================================================
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+Describe the solution you'd like
+================================
+A clear and concise description of what you want to happen.
+
+Describe alternatives you've considered
+=======================================
+A clear and concise description of any alternative solutions or features you've considered.
+
+Additional context
+==================
+Add any other context or screenshots about the feature request here.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# How Can I Contribute?
+
+You can contribute to the project by fixing bugs or by suggesting enhancements.
+
+## Reporting Bugs
+
+This section guides you through submitting a bug report for ObsRailsTemplate. Following these guidelines helps maintainers and the community understand your report, reproduce the behaviour, and find related reports.
+
+Before creating bug reports, please:
+- **Check the [issues page](https://github.com/openSUSE/obs_rails_template/issues)** as you may find that you don't need to create one. If you find the issue already reported **and it is still open**, add a comment to the existing issue instead of opening a new one.
+- **Check the [mailing list](https://link-to-your-repositorys-mailing-list)** to see if there is already a discussion going on.
+
+To create a bug report, fill out the [required template](https://github.com/openSUSE/obs_rails_template/issues/new?assignees=&labels=&template=Bug_report.md), the information it asks for helps us resolve issues faster.
+
+## Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for ObsRailsTemplate, including completely new features and minor improvements to existing functionalities. Following these guidelines helps maintainers and the community understand your suggestion and find related suggestions.
+
+Before creating enhancement suggestions, please check if there's already [an issue](https://github.com/openSUSE/obs_rails_templates/issues) for that enhancement.
+
+When you are creating an enhancement suggestion, please [include as many details as possible](https://github.com/openSUSE/obs_rails_template/blob/main/CONTRIBUTING.md#how-do-i-submit-a-good-enhancement-suggestion). Fill in [the template](https://github.com/openSUSE/obs_rails_template/issues/new?assignees=&labels=&template=feature_request.md), including the steps that you imagine you would take if the feature you're requesting existed.
+
+## How Do I Submit A (Good) Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/) in our [issues page](https://github.com/openSUSE/obs_rails_template/issues). Create an issue on that repository and provide the following information:
+
+-   **Use a clear and descriptive title** for the issue to identify the suggestion.
+-   **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
+-   **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+-   **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
+-   **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to.
+
+## Your First Code Contribution
+
+Unsure where to begin contributing to ObsRailsTemplate? You can start by looking through these `beginner` and `help-wanted` issues:
+
+- [Beginner issues](https://github.com/openSUSE/obs_rails_template/issues?q=is%3Aopen+label%3A%22good+first+issue%22+sort%3Acomments-desc) - issues which should only require a few lines of code, and a test or two.
+- [Help wanted issues](https://github.com/openSUSE/obs_rails_template/issues?q=is%3Aopen+label%3A%22help+wanted+sort%3Acomments-desc) - issues which should be a bit more involved than `beginner` issues.
+
+Both issue lists are sorted by total number of comments. While not perfect, number of comments is a reasonable proxy for impact a given change will have.
+
+## Styleguides
+
+Below are some style guides that may be useful in order to ensure your contribution to the project is accepted:
+
+- [Example Git Commit Message styleguides](https://github.com/openSUSE/open-build-service/wiki/Commit-Style)
+- [Example Programming Language styleguides](https://rubystyle.guide/)
+- [Example Documentation styleguides](https://docs.gitlab.com/ee/development/documentation/styleguide/)
+
+## Talk with Us
+
+You can always reach us via the following resources and talk about contributing:
+
+- Our [mailing list](https://the-mailing-list-url)
+- Our [IRC channel](irc://the-irc-server:6667)


### PR DESCRIPTION
This commit adds the foundation for the contribution guide for a generic
OBS project. Includes basic contribution guides for fixing bugs, adding
enhancements, bug and issue templates, and main communication channels.

I've used the following resources for inspiration:
- Our own [contribution guidelines](https://github.com/openSUSE/open-build-service/blob/b4f7daa7b8db21f17392ccf494d1d7e8ab14541d/CONTRIBUTING.md)
- Atom's [contribution guidelines](https://github.com/atom/atom/blob/master/CONTRIBUTING.md)
- Rail's [contribution guidelines](https://github.com/rails/rails/blob/main/CONTRIBUTING.md)
- OpenGovernment's [contribution guidelines](https://github.com/opengovernment/opengovernment/blob/master/CONTRIBUTING.md)